### PR TITLE
feat: Simplify docker startup using docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+# To use this docker-compose.yml, run `docker compose up`. If you want to make
+# it run in the background, you instead run `docker compose up -d`. 
+name: sds_env # compose project name
+services:
+  sds_2024:
+    # Using platform condition to handle different architectures
+    # for m chips, run `DOCKER_IMAGE=jreades/sds:2024-silicon docker compose up -d` 
+    # for other platforms, no DOCKER_IMAGE need to be set, run `docker compose up -d`
+    image: ${DOCKER_IMAGE:-jreades/sds:2024-intel}
+    container_name: sds2024
+    ports:
+      - 8888:8888
+    volumes:
+      - .:/home/jovyan/work
+    command: >
+      start.sh jupyter lab --LabApp.password='' --ServerApp.password='' --NotebookApp.token=''
+    # Remove container when stopped
+    restart: "no"


### PR DESCRIPTION
# Summary
This pull request aims to simplify docker startup configuration commands using docker compose, addressing potential input errors and line break issues for users who are unfamiliar with command line operations.

# Issue
I've noticed many users encounter problems when using the command:
```bash
docker run --rm -d --name sds2024 -p 8888:8888 \
   -v "$(pwd):/home/jovyan/work" \
  jreades/sds:2024-intel start.sh jupyter lab \
  --LabApp.password='' --ServerApp.password='' --NotebookApp.token=''
```
Issues arise due to unfamiliarity with command line or input method problems, including:
- Single/double quote or Chinese quote issues
- Missing spaces causing JupyterLab to require passwords
- Line break issues across different platforms
- Misspelling "jovyan" as "joyvan" in the volume mount path, resulting in an empty work directory in Jupyter

# Implementation
I use docker compose here to simplify the docker startup configuration commands:
- For Intel platforms: Download this docker-compose.yml file and run `docker compose up -d` to start the environment
- For M chips: Download this docker-compose.yml file and run `DOCKER_IMAGE=jreades/sds:2024-silicon docker compose up -d` to start the environment

# Testing
I have tested on both Windows and macOS M chip platforms.

# Potential Problems
The choice between silicon image and intel image depends on architecture detection. I tried to directly pull sds:2024 without indicating platform but encountered issues. I also attempted to specify `platform` in docker compose, but this would require introducing .env configuration, which might increase complexity. Currently, I haven't found a unified startup command for different platforms.

- Some other options:
    - [specify platform](https://stackoverflow.com/questions/78555276/is-it-possible-to-optionally-specify-a-build-platform-for-a-service-in-a-docker)
    - [use environment variables](https://stackoverflow.com/questions/29377853/how-can-i-use-environment-variables-in-docker-compose)